### PR TITLE
Fix broken links of stylesheets and favicon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width; initial-scale=1.0, maximum-scale=1">
-    <link href="/public/ico/favicon.ico" rel="shortcut icon" type="image/x-icon">
+    <link href="public/ico/favicon.ico" rel="shortcut icon" type="image/x-icon">
     <link href="http://gmpg.org/xfn/11" rel="profile">
 
     <title>
@@ -14,8 +14,8 @@
     </title>
 
     <!-- CSS -->
-    <link rel="stylesheet" href="/public/css/code-guide.css" type="text/css">
-    <link rel="stylesheet" href="/public/css/pygments-monokai.css" type="text/css">
+    <link rel="stylesheet" href="public/css/code-guide.css" type="text/css">
+    <link rel="stylesheet" href="public/css/pygments-monokai.css" type="text/css">
   </head>
   <body>
 


### PR DESCRIPTION
The stylesheets [on the page](http://mdo.github.com/code-guide/) cannot be loaded due to the absolute reference in the HTML.
I removed the absolute path reference for stylesheets and the favicon.
