### PR TITLE
Fix meta viewport: values need to be comma separated

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    <meta name="viewport" content="width=device-width; initial-scale=1.0, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
     <link href="/public/ico/favicon.ico" rel="shortcut icon" type="image/x-icon">
     <link href="http://gmpg.org/xfn/11" rel="profile">
 


### PR DESCRIPTION
This bug was throwing an error in Chrome's console. No biggie.
