### PR TITLE
highlight the recommendations for boolean attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@ layout: default
     <blockquote>
       <p>If the attribute is present, its value must either be the empty string or [...] the attribute's canonical name, with no leading or trailing whitespace.</p>
     </blockquote>
-    <p>In short, don't add a value.</p>
+    <p><strong>In short, don't add a value.</strong></p>
   </div>
   <div class="col">
     {% highlight html %}{% include html/boolean-attributes.html %}{% endhighlight %}


### PR DESCRIPTION
Just a suggestion:

![](http://cnun.es/1fNyUVc)

What do you think?
