### PR TITLE
Correct misinformation regarding quotes in CSS attribute selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@ layout: default
       <li>Don't include spaces after commas <em>within</em> <code>rgb()</code> or <code>rgba()</code> colors, and don't preface values with a leading zero.</li>
       <li>Lowercase all hex values, e.g., <code>#fff</code>. Lowercase letters are much easier to discern when scanning a document as they tend to have more unique shapes.</li>
       <li>Use shorthand hex values where available, e.g., <code>#fff</code> instead of <code>#ffffff</code>.</li>
-      <li>Quote attribute values in selectors, e.g., <code>input[type="text"]</code>. The <a href="http://www.w3.org/TR/CSS2/selector.html#matching-attrs">CSS 2.1 spec</a> shows them as optional, but it's a good practice for consistency.</li>
+      <li>Quote attribute values in selectors, e.g., <code>input[type="text"]</code>. <a href="http://mathiasbynens.be/notes/unquoted-attribute-values#css">They’re only optional in some cases</a>, and it’s a good practice for consistency.</li>
       <li>Avoid specifying units for zero values, e.g., <code>margin: 0;</code> instead of <code>margin: 0px;</code>.</li>
     </ul>
     <p>Questions on the terms used here? See the <a href="http://en.wikipedia.org/wiki/Cascading_Style_Sheets#Syntax">syntax section of the Cascading Style Sheets article</a> on Wikipedia.</p>


### PR DESCRIPTION
The CSS 2.1 spec doesn’t show quotes around attribute values “as optional” at all. Whether they can or cannot be omitted depends entirely on the attribute value. See http://mathiasbynens.be/notes/unquoted-attribute-values#css for details, or http://mothereff.in/unquoted-attributes for a tool that probably visualizes this more clearly.
