### PR TITLE
Proper capitalization for Less and Sass

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ layout: default
       <li><a href="#css-prefixed-properties">Prefixed properties</a></li>
       <li><a href="#css-single-declarations">Rules with single declarations</a></li>
       <li><a href="#css-shorthand">Shorthand notation</a></li>
-      <li><a href="#css-nesting">Nesting in LESS and SASS</a></li>
+      <li><a href="#css-nesting">Nesting in Less and Sass</a></li>
       <li><a href="#css-comments">Comments</a></li>
       <li><a href="#css-classes">Classes</a></li>
       <li><a href="#css-selectors">Selectors</a></li>
@@ -273,7 +273,7 @@ layout: default
 
 <div class="section" id="css-nesting">
   <div class="col">
-    <h3>Nesting in LESS and SASS</h3>
+    <h3>Nesting in Less and Sass</h3>
     <p>Avoid unnecessary nesting. Just because you can nest, doesn't mean you always should. Consider nesting only if you must scope styles to a parent and if there are multiple elements to be nested.</p>
   </div>
   <div class="col">


### PR DESCRIPTION
Whenever Less and Sass are mentioned on their respective websites they are always referred to as 'Less' and 'Sass' with the first letter capitalized and the rest of them lowercased.
