### PR TITLE
update html attribute list w/ accessibility attrs

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,8 @@ layout: default
       <li><code>id</code>, <code>name</code></li>
       <li><code>data-*</code></li>
       <li><code>src</code>, <code>for</code>, <code>type</code>, <code>href</code></li>
+      <li><code>title</code>, <code>alt</code></li>
+      <li><code>aria-*</code>, <code>role</code></li>
     </ul>
     <p>Classes make for great reusable components, so they come first. Ids are more specific and should be used sparingly (e.g., for in-page bookmarks), so they come second.</p>
   </div>


### PR DESCRIPTION
added `title` text, `alt` text, `aria-*` (e.g. `aria-hidden`), and `role` attributes.

NOTE: `title` should always be after `href`, and `alt` should be after `src` (e.g. in an `<img>`). I've found that the last two attributes are usually added on the end if necessary (e.g. if the element isn't semantically correct or something needs to be hidden on screen readers).
