### PR TITLE
Add rule: don’t omit optional closing tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@ layout: default
       <li>Nested elements should be indented once (two spaces).</li>
       <li>Always use double quotes, never single quotes, on attributes.</li>
       <li>Don't include a trailing slash in self-closing elements—the <a href="http://dev.w3.org/html5/spec-author-view/syntax.html#syntax-start-tag">HTML5 spec</a> says they're optional.</li>
+      <li>Don’t omit optional closing tags, like <code>&lt;/li&gt;</code> or <code>&lt;/body&gt;</code></li>
     </ul>
   </div>
   <div class="col">


### PR DESCRIPTION
Example already showed not to omit optional closing tags, but it wasn't made explicit as a rule, even though it should be. :-)
