### PR TITLE
Disables the quirks mode option in IE

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,7 @@
 <html lang="en-us">
   <head>
     <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
     <link href="public/ico/favicon.ico" rel="shortcut icon" type="image/x-icon">
 


### PR DESCRIPTION
Add X-UA-Compatible meta tag to disable the quirks mode option in IE9 (which breaks the formatting of the site).
