### PR TITLE
Add link to Italian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Heavily inspired by [Idiomatic CSS](https://github.com/necolas/idiomatic-css) an
 
 Translations are maintained by their creators and may not always be up to date with the original here.
 
-- [Portuguese](http://diegoeis.github.io/code-guide/) - Translated by [Diego Eis](http://tableless.com.br/)  
-- [Spanish](http://adrianayala.mx/code-guide/es/) - Translated by [Adrian Ayala](http://adrianayala.mx/)  
+- [Portuguese](http://diegoeis.github.io/code-guide/) - Translated by [Diego Eis](http://tableless.com.br/)
+- [Spanish](http://adrianayala.mx/code-guide/es/) - Translated by [Adrian Ayala](http://adrianayala.mx/)
 - [Indonesian](http://diagramatics.github.io/code-guide-id) - Translated by [Steven Sinatra](http://diagramatics.me)
-- [Chinese](http://zoomzhao.github.io/code-guide/) - Translated by [Zoom Zhao](https://github.com/ZoomZhao)  
+- [Chinese](http://zoomzhao.github.io/code-guide/) - Translated by [Zoom Zhao](https://github.com/ZoomZhao)
+- [Italian](http://alessandro1997.github.io/code-guide/) - Translated by [Alessandro Desantis](https://github.com/alessandro1997)
 
 Have a translation you'd like to link to? Open a pull request to add it.
 


### PR DESCRIPTION
It looks like Sublime Text 2 removed some trailing whitespace in the README, as well. Is it a problem?
