### PR TITLE
Add reason for new lines at end of files

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,8 +402,8 @@ layout: default
       <li>Use soft-tabs set to two spaces.</li>
       <li>Trim trailing white space on save.</li>
       <li>Set encoding to UTF-8.</li>
-      <li>Add new line at end of files.</li>
     </ul>
+    <p>Also add a new line at end of files, as this will help when concatenating files together. Learn more <a href="http://evanhahn.com/newline-necessary-at-the-end-of-javascript-files/">about why this is necessary for JavaScript files</a>.
     <p>Consider documenting and applying these preferences to your project's <code>.editorconfig</code> file. For an example, see <a href="https://github.com/twbs/bootstrap/blob/master/.editorconfig">the one in Bootstrap</a>. Learn more <a href="http://editorconfig.org">about EditorConfig</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
Fixes #93. Links to [this article](http://evanhahn.com/newline-necessary-at-the-end-of-javascript-files/) to explain why it should be done, specifically for JS files.
