### PR TITLE
Include `value`in the HTML Attribute Order

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@ layout: default
       <li><code>class</code></li>
       <li><code>id</code>, <code>name</code></li>
       <li><code>data-*</code></li>
-      <li><code>src</code>, <code>for</code>, <code>type</code>, <code>href</code></li>
+      <li><code>src</code>, <code>for</code>, <code>type</code>, <code>href</code>, <code>value</code></li>
       <li><code>title</code>, <code>alt</code></li>
       <li><code>aria-*</code>, <code>role</code></li>
     </ul>


### PR DESCRIPTION
Was thinking that `value` was important enough of an attribute to be included in the section about HTML Attribute Order. I put it in line with `src`, `for`, `type`, and `href` because it seemed most closely related to those attributes, as compared with the others.
