### PR TITLE
Reorder the elements in import

### DIFF
--- a/_includes/css/import.html
+++ b/_includes/css/import.html
@@ -1,7 +1,7 @@
-<!-- Use link elements -->
-<link rel="stylesheet" href="core.css">
-
 <!-- Avoid @imports -->
 <style>
   @import url("more.css");
 </style>
+
+<!-- Use link elements -->
+<link rel="stylesheet" href="core.css">


### PR DESCRIPTION
As happens in:

CSS -> Shorthand notation
CSS -> Nesting in Less and Sass

First appears the bad way and next the good way to do it. So I think made more sense to have a uniform in all elements, first the way to avoid and after the way how should be do it.
