### PR TITLE
Update ie-compatibility-mode.html

### DIFF
--- a/_includes/html/ie-compatibility-mode.html
+++ b/_includes/html/ie-compatibility-mode.html
@@ -1,1 +1,1 @@
-<meta http-equiv="X-UA-Compatible" content="IE=Edge">
+<meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
This is really minor, I know, but HTML5 Boilerplate changed this to all lower case. With Gzip compression on it can save 3 bytes. :-)
REF: https://github.com/h5bp/html5-boilerplate/issues/1656
