### PR TITLE
Correct 'lang' attribute in html tag

### DIFF
--- a/_includes/html/lang.html
+++ b/_includes/html/lang.html
@@ -1,3 +1,3 @@
-<html lang="en-us">
+<html lang="en">
   <!-- ... -->
 </html>


### PR DESCRIPTION
I replaced `lang="en-us"` with `lang="en"` in `html` tag. A few reasons:

- This code-guide links to [a list of language codes](https://www.sitepoint.com/web-foundations/iso-2-letter-language-codes/) for the `lang` attributes which contains `EN` for American English.
- An example in [the specification](http://w3c.github.io/html/semantics.html#the-html-element) uses `lang="en"`
- GitHub.com uses `lang="en"`, too.