### PR TITLE
fix the "Start reading ☞" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code Guide is a project for documenting standards for developing flexible, durable, and sustainable HTML and CSS. It comes from years of experience writing code on projects of all sizes. It's not the end-all be-all, but it's a start.
 
-**[Start reading ☞](http://mdo.github.io/code-guide)**
+**[Start reading ☞](https://mdo.github.io/code-guide)**
 
 ---
 


### PR DESCRIPTION
if you use `http` . It will return blank page.
And `https` can redirect to `codeguide.co` normally because of CNAME.