### PR TITLE
Add  role="main" to main

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
 
     {% include header.html %}
 
-    <main class="container">
+    <main class="container" role="main">
       {{ content }}
     </main>
 


### PR DESCRIPTION
just like Bootstrap does. This is for the benefit for IE11 as that browser doesn't know about the 'main' element.