### PR TITLE
Lower case to match style guide

### DIFF
--- a/_includes/html/encoding.html
+++ b/_includes/html/encoding.html
@@ -1,3 +1,3 @@
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
 </head>


### PR DESCRIPTION
This makes the code snippet match the actual best practice that this site is actually using.

Also, I am inserting a preference for lower case utf-8, preferred over UTF-8, because lower case letters compress better than upper case letters.

This different is negligible, perhaps one or two bits on every HTML document ever. But removing a seemingly equivalent option ("UTF-8") from consideration is priceless.