### PR TITLE
Remove unneeded shortcut from icon meta tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">
+    <link href="/favicon.ico" rel="icon" type="image/x-icon">
 
     <title>
       {{ site.name }}


### PR DESCRIPTION
This isn't needed and was never part of the spec.
Great article here: https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs#did-we-forget-anyone

Also:
mathiasbynens.be/notes/rel-shortcut-icon