### PR TITLE
Always load CarbonAds over HTTPS

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,6 +11,6 @@
       Created by <a href="https://markdotto.com">@mdo</a> &middot; v{{ site.version }} &middot; <a href="https://github.com/mdo/code-guide/">GitHub repo</a>
     </p>
 
-    <script async src="//cdn.carbonads.com/carbon.js?serve=CKYI52JU&placement=codeguide" id="_carbonads_js"></script>
+    <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYI52JU&placement=codeguide" id="_carbonads_js"></script>
   </div>
 </header>


### PR DESCRIPTION
Fixes a WebHint warning.
https://webhint.io/docs/user-guide/hints/hint-no-protocol-relative-urls/